### PR TITLE
LinkLocal Conversion

### DIFF
--- a/ll_conversion.py
+++ b/ll_conversion.py
@@ -1,0 +1,57 @@
+#!/usr/bin/python
+
+from __future__ import print_function
+import subprocess
+import time
+import argparse
+
+parser = argparse.ArgumentParser(description='linklocal conversion')
+parser.add_argument(
+    '--show-only',
+    help='will show commands it will run',
+    action='store_true',
+    required=False
+)
+args = vars(parser.parse_args())
+
+show_only = args["show_only"]
+
+def run_cmd(cmd):
+    m_cmd = "cli --quiet --no-login-prompt --user network-admin:test123 " + cmd
+    if show_only and "-show" not in cmd:
+        print(">>> " + cmd)
+        return
+    try:
+        proc = subprocess.Popen(m_cmd, shell=True, stdout=subprocess.PIPE)
+        output = proc.communicate()[0]
+        return output.strip().split('\n')
+    except:
+        print("Failed running cmd %s" % m_cmd)
+        exit(0)
+
+def sleep(sec):
+    if not show_only:
+        time.sleep(sec)
+
+def get_ll_ipv6(global_ipv6):
+    global_ipv6 = global_ipv6.replace('::', ':')
+    return "fe80:" + global_ipv6[4:]
+
+intf_info = run_cmd("vrouter-interface-show format ip,ip2,linklocal,nic parsable-delim ,")
+for intf in intf_info:
+    if not intf:
+        print("No vrouter interfaces found")
+        exit(0)
+    vrname,ip1,ip2,ll,nic = intf.split(",")
+    if ":" in ip1:
+        new_ll = get_ll_ipv6(ip1)
+        run_cmd("vrouter-interface-ip-add vrouter-name %s nic %s ip %s" % (vrname, nic, new_ll))
+    elif ":" in ip2:
+        new_ll = get_ll_ipv6(ip2)
+        run_cmd("vrouter-interface-ip-add vrouter-name %s nic %s ip %s" % (vrname, nic, new_ll))
+    else:
+        continue
+
+################################################
+print("DONE")
+################################################


### PR DESCRIPTION
```
root@hmplabpsq-we60100:/var/tmp# python ll_conversion.py --show-only
>>> vrouter-interface-ip-add vrouter-name hmplabpsq-we60100-vrouter nic eth0.4092 ip fe80::0:167f:b001:46
>>> vrouter-interface-ip-add vrouter-name hmplabpsq-we60100-vrouter nic eth0.4091 ip fe80::0:167f:b001:40
>>> vrouter-interface-ip-add vrouter-name hmplabpsq-we60100-vrouter nic eth0.4090 ip fe80::0:167f:b001:4e
>>> vrouter-interface-ip-add vrouter-name hmplabpsq-we60100-vrouter nic eth0.4089 ip fe80::0:167f:b001:4a
>>> vrouter-interface-ip-add vrouter-name hmplabpsq-we60100-vrouter nic eth0.4088 ip fe80::0:167f:b001:52
>>> vrouter-interface-ip-add vrouter-name hmplabpsq-we60100-vrouter nic eth0.4087 ip fe80::0:167f:b001:56
>>> vrouter-interface-ip-add vrouter-name hmplabpsq-we60100-vrouter nic eth0.4086 ip fe80::0:167f:b001:42
>>> vrouter-interface-ip-add vrouter-name hmplabpsq-we60200-vrouter nic eth3.4092 ip fe80::0:167f:b001:50
>>> vrouter-interface-ip-add vrouter-name hmplabpsq-we60200-vrouter nic eth1.4091 ip fe80::0:167f:b001:58
>>> vrouter-interface-ip-add vrouter-name hmplabpsq-we60200-vrouter nic eth1.4090 ip fe80::0:167f:b001:48
>>> vrouter-interface-ip-add vrouter-name hmplabpsq-we60200-vrouter nic eth1.4089 ip fe80::0:167f:b001:54
>>> vrouter-interface-ip-add vrouter-name hmplabpsq-we60200-vrouter nic eth1.4088 ip fe80::0:167f:b001:44
>>> vrouter-interface-ip-add vrouter-name hmplabpsq-we60200-vrouter nic eth1.4087 ip fe80::0:167f:b001:4c
>>> vrouter-interface-ip-add vrouter-name hmplabpsq-we50600-vrouter nic eth2.4092 ip fe80::0:167f:b001:57
>>> vrouter-interface-ip-add vrouter-name hmplabpsq-we50600-vrouter nic eth3.4091 ip fe80::0:167f:b001:59
>>> vrouter-interface-ip-add vrouter-name hmplabpsq-we50600-vrouter nic eth5.4040 ip fe80::0:167f:b001:a5
>>> vrouter-interface-ip-add vrouter-name hmplabpsq-we50300-vrouter nic eth3.490 ip fe80::0:167f:b002:102
>>> vrouter-interface-ip-add vrouter-name hmplabpsq-we50300-vrouter nic eth5.490 ip fe80::0:167f:b002:101
>>> vrouter-interface-ip-add vrouter-name hmplabpsq-we50300-vrouter nic eth7.4092 ip fe80::0:167f:b001:4b
>>> vrouter-interface-ip-add vrouter-name hmplabpsq-we50300-vrouter nic eth7.4091 ip fe80::0:167f:b001:4d
>>> vrouter-interface-ip-add vrouter-name hmplabpsq-we50300-vrouter nic eth2.4040 ip fe80::0:167f:b001:a2
>>> vrouter-interface-ip-add vrouter-name hmplabpsq-we50100-vrouter nic eth0.490 ip fe80::0:167f:b002:2
>>> vrouter-interface-ip-add vrouter-name hmplabpsq-we50100-vrouter nic eth2.490 ip fe80::0:167f:b002:1
>>> vrouter-interface-ip-add vrouter-name hmplabpsq-we50100-vrouter nic eth4.4092 ip fe80::0:167f:b001:41
>>> vrouter-interface-ip-add vrouter-name hmplabpsq-we50100-vrouter nic eth4.4091 ip fe80::0:167f:b001:43
>>> vrouter-interface-ip-add vrouter-name hmplabpsq-we50100-vrouter nic eth2.4090 ip fe80::0:167f:b001:45
>>> vrouter-interface-ip-add vrouter-name hmplabpsq-we50100-vrouter nic eth0.4040 ip fe80::0:167f:b001:a0
>>> vrouter-interface-ip-add vrouter-name hmplabpsq-we50400-vrouter nic eth8.490 ip fe80::0:167f:b002:103
>>> vrouter-interface-ip-add vrouter-name hmplabpsq-we50400-vrouter nic eth10.490 ip fe80::0:167f:b002:101
>>> vrouter-interface-ip-add vrouter-name hmplabpsq-we50400-vrouter nic eth1.4092 ip fe80::0:167f:b001:4f
>>> vrouter-interface-ip-add vrouter-name hmplabpsq-we50400-vrouter nic eth2.4091 ip fe80::0:167f:b001:51
>>> vrouter-interface-ip-add vrouter-name hmplabpsq-we50400-vrouter nic eth3.4040 ip fe80::0:167f:b001:a3
>>> vrouter-interface-ip-add vrouter-name hmplabpsq-we50500-vrouter nic eth6.4092 ip fe80::0:167f:b001:53
>>> vrouter-interface-ip-add vrouter-name hmplabpsq-we50500-vrouter nic eth6.4091 ip fe80::0:167f:b001:55
>>> vrouter-interface-ip-add vrouter-name hmplabpsq-we50500-vrouter nic eth4.4040 ip fe80::0:167f:b001:a4
>>> vrouter-interface-ip-add vrouter-name hmplabpsq-we50200-vrouter nic eth6.490 ip fe80::0:167f:b002:3
>>> vrouter-interface-ip-add vrouter-name hmplabpsq-we50200-vrouter nic eth11.490 ip fe80::0:167f:b002:1
>>> vrouter-interface-ip-add vrouter-name hmplabpsq-we50200-vrouter nic eth5.4092 ip fe80::0:167f:b001:47
>>> vrouter-interface-ip-add vrouter-name hmplabpsq-we50200-vrouter nic eth5.4091 ip fe80::0:167f:b001:49
>>> vrouter-interface-ip-add vrouter-name hmplabpsq-we50200-vrouter nic eth1.4040 ip fe80::0:167f:b001:a1
DONE

root@hmplabpsq-we60100:/var/tmp# cli
Netvisor OS Command Line Interface 3.0
Connected to Switch hmplabpsq-we60100; nvOS Identifier:0xb000aae; Ver: 3.0.3000012816
CLI (network-admin@hmplabpsq-we60100) > vrouter-interface-ip-add vrouter-name hmplabpsq-we60100-vrouter nic eth0.4092 ip fe80::0:167f:b001:46
Added IP to interface

CLI (network-admin@hmplabpsq-we60100) > vrouter-interface-show vrouter-name hmplabpsq-we60100-vrouter nic eth0.4092                                                                                                                                   vrouter-name              nic       ip               ip2                      linklocal          mac               vlan vlan-type nic-state l3-port mtu
------------------------- --------- ---------------- ------------------------ ------------------ ----------------- ---- --------- --------- ------- ----
hmplabpsq-we60100-vrouter eth0.4092 104.255.61.74/31 2620:0:167f:b001::46/127 fe80::167f:b001:46 66:0e:94:ae:a1:69 4092 public    up        41      9216
```