### PR TITLE
Multi-fabric full-mesh ping script

### DIFF
--- a/multi_fabric_fullmesh_ping.py
+++ b/multi_fabric_fullmesh_ping.py
@@ -1,0 +1,248 @@
+#!/usr/bin/python
+
+""" PN Vrouter Full Mesh Ping Test """
+
+from __future__ import print_function
+import subprocess
+import time
+import sys
+import argparse
+import signal
+
+g_ping_interval = 3 # in minutes
+
+##################
+# ARGUMENT PARSING
+##################
+
+parser = argparse.ArgumentParser(description='Full Mesh Ping')
+parser.add_argument(
+    '-c', '--count',
+    help='number of times to run this script',
+    required=False,
+    default=1
+)
+parser.add_argument(
+    '-s', '--seed-switch',
+    help='fabric seed switch',
+    required=True
+)
+parser.add_argument(
+    '-r', '--remote-seed-switch',
+    help='remote fabric seed switch',
+    required=False
+)
+parser.add_argument(
+    '-d', '--dual-stack',
+    help='ping ipv6 interfaces as well',
+    action='store_true',
+    required=False
+)
+parser.add_argument(
+    '-a', '--all',
+    help='ping all interfaces including vlan based interfaces',
+    action='store_true',
+    required=False
+)
+parser.add_argument(
+    '-v', '--verbose',
+    help='verbose mode',
+    action='store_true',
+    required=False
+)
+args = vars(parser.parse_args())
+
+try:
+    g_count = int(args["count"])
+except:
+    print("Invalid value passed to argument count")
+    exit(0)
+
+seed_switch = args["seed_switch"]
+
+if args["remote_seed_switch"]:
+    remote_seed_switch = args["remote_seed_switch"]
+else:
+    remote_seed_switch = None
+
+if args["all"]:
+    ping_all = True
+else:
+    ping_all = False
+
+if args["dual_stack"]:
+    dual_stack = True
+else:
+    dual_stack = False
+
+def sys_write(msg):
+    sys.stdout.write(msg)
+    sys.stdout.flush()
+
+def sys_print(msg, nl=True):
+    if nl:
+        print(msg)
+    else:
+        print(msg, end='')
+    sys.stdout.flush()
+
+def sys_exit(msg=None):
+    if msg:
+        sys_print(msg)
+    exit(0)
+
+def run_cmd(cmd, switch=None):
+    if switch:
+        cmd_prefix = ("sshpass -p test123 ssh -q -oStrictHostKeyChecking=no "
+                      "-oConnectTimeout=10 network-admin@%s " % (switch))
+    else:
+        cmd_prefix = "cli "
+    cmd = cmd_prefix + cmd + " 2>/dev/null"
+    try:
+        proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
+        output = proc.communicate()[0]
+        if ("Netvisor OS Command Line Interface" in output):
+            output = output[output.index("Netvisor OS Command Line Interface"):]
+        return output.strip().split('\n')
+    except:
+        sys_exit("Failed running cmd %s" % cmd)
+
+def is_reachable(vrname, ip_addr, switch=None):
+    if vrname:
+        out = run_cmd("vrouter-ping vrouter-name %s host-ip %s "
+                      "count 1" % (vrname, ip_addr), switch)
+    else:
+        out = run_cmd("ping -c 1 %s" % (ip_addr), switch)
+
+    message = '\n'.join(out)
+    if ('unreachable' in message or 'Unreachable' in message or
+            '100% packet loss' in message):
+        return (False, "")
+    rtt = ""
+    for msg in out:
+        if "round-trip" in msg:
+            rtt = msg
+            break
+    return (True, rtt)
+
+def spinning_cursor():
+    while True:
+        for cursor in '|/-\\':
+            yield cursor
+
+def get_vr_ips(switch=None):
+    intf_info = run_cmd("vrouter-interface-show format l3-port,ip,%svrrp-state "
+                        "parsable-delim ," % ("ip2," if dual_stack else ""), switch)
+    vr_ips = {}
+    for intf in intf_info:
+        if not intf:
+            sys_exit("No router interface exists")
+        if ',' not in intf:
+            continue
+        if dual_stack:
+            vrname,l3_port,ip1_cidr,ip2_cidr,vrrp_state = intf.split(',')
+        else:
+            vrname,l3_port,ip1_cidr,vrrp_state = intf.split(',')
+        if vrrp_state == "slave":
+            continue
+        if not ping_all and not l3_port:
+            continue
+        ip1 = ip1_cidr.split('/')[0]
+        if vr_ips.get(vrname, None):
+            vr_ips[vrname].append(ip1)
+        else:
+            vr_ips[vrname] = [ip1]
+        if dual_stack and ip2_cidr:
+            ip2 = ip2_cidr.split('/')[0]
+            if vr_ips.get(vrname, None):
+                vr_ips[vrname].append(ip2)
+            else:
+                vr_ips[vrname] = [ip2]
+    return vr_ips
+
+def signal_handler(signal, frame):
+        sys_write('Exiting...')
+        sys_exit("Done")
+
+def update_progress(vrname, fmsg, smsg):
+    if fmsg:
+        sys_print("Failure")
+    else:
+        sys_print("Success")
+    if args["verbose"] and smsg:
+        sys_print("  > Passed for following IPs:")
+        for msg in smsg:
+            sys_print(" "*4 + "* " + msg)
+    if fmsg:
+        sys_print("  > Failed for following IPs:")
+        for msg in fmsg:
+            sys_print(" "*4 + "* " + msg)
+
+result, _ = is_reachable(None, seed_switch)
+if not result:
+    sys_exit("Switch %s is not reachable" % seed_switch)
+
+if remote_seed_switch:
+    result, _ = is_reachable(None, remote_seed_switch)
+    if not result:
+        sys_exit("Switch %s is not reachable" % remote_seed_switch)
+
+signal.signal(signal.SIGINT, signal_handler)
+spinner = spinning_cursor()
+sys_print("Fetching all l3 link IPs from %s..." % seed_switch, nl=False)
+vr_ips = get_vr_ips(seed_switch)
+sys_print("Done\n")
+if remote_seed_switch:
+    sys_print("Fetching all l3 link IPs from remote fabric switch "
+              "%s..." % remote_seed_switch, nl=False)
+    rem_vr_ips = get_vr_ips(remote_seed_switch)
+    sys_print("Done\n")
+vrlen = len(vr_ips)
+sys_print("Performing ping test:")
+sys_print("=====================")
+for _i in range(g_count):
+    if _i > 0:
+        sys_print("Waiting for %s minute(s)" % g_ping_interval)
+        time.sleep(60*g_ping_interval)
+    for vrname in vr_ips:
+        sys_print("  From %s to all l3 links : " % (vrname), nl=False)
+        fmsg = []
+        smsg = []
+        for vr in vr_ips:
+            if vrname == vr:
+                continue
+            else:
+                for ip in vr_ips[vr]:
+                    sys_write(spinner.next())
+                    result, rtt = is_reachable(vrname, ip, seed_switch)
+                    if not result:
+                        fail = True
+                        fmsg.append(ip)
+                    else:
+                        if rtt:
+                            smsg.append(ip + " - " + rtt)
+                        else:
+                            smsg.append(ip)
+                    time.sleep(0.5)
+                    sys_write('\b')
+        update_progress(vrname, fmsg, smsg)
+        if remote_seed_switch:
+            for rem_vr in rem_vr_ips:
+                fmsg = []
+                smsg = []
+                sys_print("  From %s to all l3 links of remote vrouter "
+                          "%s: " % (vrname, rem_vr), nl=False)
+                for ip in rem_vr_ips[rem_vr]:
+                    sys_write(spinner.next())
+                    result, rtt = is_reachable(vrname, ip, seed_switch)
+                    if not result:
+                        fail = True
+                        fmsg.append(ip)
+                    else:
+                        if rtt:
+                            smsg.append(ip + " - " + rtt)
+                        else:
+                            smsg.append(ip)
+                    time.sleep(0.5)
+                    sys_write('\b')
+                update_progress(vrname, fmsg, smsg)


### PR DESCRIPTION
```
root@auto-server:~# python multi_fabric_fullmesh_ping.py -s ghspine01 -r ghspine-ursa -v
Fetching all l3 link IPs from ghspine01...Done

Fetching all l3 link IPs from remote fabric switch ghspine-ursa...Done

Performing ping test:
=====================
  From ghq-spine1-hw-Campus to all l3 links : Failure
  > Passed for following IPs:
    * 10.60.7.37 - round-trip (ms)  min/avg/max/stddev = 0.223/0.223/0.223/-NaN
    * 10.60.26.141 - round-trip (ms)  min/avg/max/stddev = 0.193/0.193/0.193/-NaN
    * 10.60.7.29 - round-trip (ms)  min/avg/max/stddev = 0.196/0.196/0.196/-NaN
    * 10.60.30.5 - round-trip (ms)  min/avg/max/stddev = 0.188/0.188/0.188/-NaN
    * 10.60.30.13 - round-trip (ms)  min/avg/max/stddev = 0.226/0.226/0.226/-NaN
    * 10.60.26.129 - round-trip (ms)  min/avg/max/stddev = 0.162/0.162/0.162/-NaN
    * 10.60.26.121 - round-trip (ms)  min/avg/max/stddev = 0.393/0.393/0.393/-NaN
  > Failed for following IPs:
    * 10.60.7.53
    * 10.60.7.45
    * 10.60.7.21
    * 10.60.7.5
    * 10.60.7.13
    * 10.60.26.133
    * 10.60.26.125
  From ghq-spine1-hw-Campus to all l3 links of remote vrouter ghq-spine1-hw-WAN: Success
  > Passed for following IPs:
    * 10.60.26.2 - round-trip (ms)  min/avg/max/stddev = 0.250/0.250/0.250/-NaN
    * 10.60.26.13 - round-trip (ms)  min/avg/max/stddev = 0.384/0.384/0.384/-NaN
    * 10.60.26.121 - round-trip (ms)  min/avg/max/stddev = 0.208/0.208/0.208/-NaN
  From ghq-spine1-hw-Campus to all l3 links of remote vrouter uss-spine1-hw-WAN: Success
  > Passed for following IPs:
    * 10.60.26.6 - round-trip (ms)  min/avg/max/stddev = 0.190/0.190/0.190/-NaN
    * 10.60.26.10 - round-trip (ms)  min/avg/max/stddev = 0.194/0.194/0.194/-NaN
    * 10.60.26.129 - round-trip (ms)  min/avg/max/stddev = 0.220/0.220/0.220/-NaN
  From uss-spine1-hw-Campus to all l3 links : Failure
  > Passed for following IPs:
    * 10.60.26.137 - round-trip (ms)  min/avg/max/stddev = 0.218/0.218/0.218/-NaN
    * 10.60.7.25 - round-trip (ms)  min/avg/max/stddev = 0.226/0.226/0.226/-NaN
    * 10.60.30.1 - round-trip (ms)  min/avg/max/stddev = 0.233/0.233/0.233/-NaN
    * 10.60.30.9 - round-trip (ms)  min/avg/max/stddev = 0.235/0.235/0.235/-NaN
    * 10.60.26.129 - round-trip (ms)  min/avg/max/stddev = 0.218/0.218/0.218/-NaN
    * 10.60.26.121 - round-trip (ms)  min/avg/max/stddev = 0.213/0.213/0.213/-NaN
  > Failed for following IPs:
    * 10.60.6.37
    * 10.60.7.33
    * 10.60.7.49
    * 10.60.7.41
    * 10.60.7.17
    * 10.60.7.1
    * 10.60.7.9
    * 10.60.26.133
    * 10.60.26.125
  From uss-spine1-hw-Campus to all l3 links of remote vrouter ghq-spine1-hw-WAN: Success
  > Passed for following IPs:
    * 10.60.26.2 - round-trip (ms)  min/avg/max/stddev = 0.235/0.235/0.235/-NaN
    * 10.60.26.13 - round-trip (ms)  min/avg/max/stddev = 0.188/0.188/0.188/-NaN
    * 10.60.26.121 - round-trip (ms)  min/avg/max/stddev = 0.185/0.185/0.185/-NaN
```

Supported options:
```
# python multi_fabric_fullmesh_ping.py -h
usage: multi_fabric_fullmesh_ping.py [-h] [-c COUNT] -s SEED_SWITCH
                                     [-r REMOTE_SEED_SWITCH] [-d] [-a] [-v]

Full Mesh Ping

optional arguments:
  -h, --help            show this help message and exit
  -c COUNT, --count COUNT
                        number of times to run this script
  -s SEED_SWITCH, --seed-switch SEED_SWITCH
                        fabric seed switch
  -r REMOTE_SEED_SWITCH, --remote-seed-switch REMOTE_SEED_SWITCH
                        remote fabric seed switch
  -d, --dual-stack      ping ipv6 interfaces as well
  -a, --all             ping all interfaces including vlan based interfaces
  -v, --verbose         verbose mode
```